### PR TITLE
Change TypeScript `module` from `commonjs` to `es2015`

### DIFF
--- a/dev/main.ts
+++ b/dev/main.ts
@@ -1,5 +1,5 @@
 import VueThailandAddress from '@/index';
-import * as Vue from 'vue';
+import Vue from 'vue';
 import App from './App.vue';
 
 Vue.use(VueThailandAddress);

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
     "build:common": "webpack --config ./build/webpack.common.config.ts",
     "build:esm": "webpack --config ./build/webpack.esm.config.ts",
     "build:web": "webpack --config ./build/webpack.web.config.ts",
-    "build": "run-p build:*",
+    "build": "cross-env TS_NODE_COMPILER_OPTIONS={\\\"module\\\":\\\"commonjs\\\"} run-p build:*",
     "dev": "poi",
     "sync:db": "ts-node ./scripts/sync-db.ts",
-    "sync": "npm-run-all sync:*",
+    "sync": "cross-env TS_NODE_COMPILER_OPTIONS={\\\"module\\\":\\\"commonjs\\\"} npm-run-all sync:*",
     "test": "npm run lint"
   },
   "repository": {
@@ -63,6 +63,7 @@
     "babel-preset-vue-app": "^1.2.0",
     "chalk": "^2.1.0",
     "copy-webpack-plugin": "^4.0.1",
+    "cross-env": "^5.0.5",
     "css-loader": "^0.28.4",
     "eslint": "^4.4.1",
     "eslint-config-gluons": "^2.0.2",

--- a/poi.config.js
+++ b/poi.config.js
@@ -6,11 +6,5 @@ module.exports = {
 	},
 	presets: [
 		require('poi-preset-typescript')()
-	],
-	extendWebpack(config) {
-		config.resolve
-			.alias
-			.set('vue$', 'vue/dist/vue.runtime.common.js')
-			.set('vuex$', 'vuex/dist/vuex.js');
-	}
+	]
 };

--- a/src/components/AddressForm.vue
+++ b/src/components/AddressForm.vue
@@ -13,7 +13,7 @@
 </template>
 
 <script lang="ts">
-import * as Vue from 'vue';
+import Vue from 'vue';
 import Component from 'vue-class-component';
 import { Prop } from 'vue-property-decorator';
 import AddressEntry from '@/interface/AddressEntry';

--- a/src/components/Autocomplete.vue
+++ b/src/components/Autocomplete.vue
@@ -11,7 +11,7 @@ ul.typeahead-autocomplete(:style='style', v-if='hasData')
 </template>
 
 <script lang="ts">
-import * as Vue from 'vue';
+import Vue from 'vue';
 import Component from 'vue-class-component';
 import { Prop } from 'vue-property-decorator';
 import AddressEntry from '@/interface/AddressEntry';

--- a/src/components/TypeaheadInput.vue
+++ b/src/components/TypeaheadInput.vue
@@ -33,7 +33,7 @@
 </template>
 
 <script lang="ts">
-import * as Vue from 'vue';
+import Vue from 'vue';
 import Component from 'vue-class-component';
 import { Prop } from 'vue-property-decorator';
 import AddressEntry from '@/interface/AddressEntry';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import AddressForm from '@/components/AddressForm.vue';
-import * as V from 'vue';
+import V from 'vue';
 
 function install(Vue: typeof V) {
 	Vue.component('address-form', AddressForm);

--- a/src/lib/datasource-utils.ts
+++ b/src/lib/datasource-utils.ts
@@ -1,4 +1,4 @@
-import database = require('@/data/db.json');
+import database from '@/data/db.json';
 import AddressEntry from '@/interface/AddressEntry';
 import * as filter from 'array-filter';
 import { calculateSimilarity } from './utils';

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -13,7 +13,9 @@ const clearAutocompleteList = ({ dispatch }: ActionContext<State, any>) => {
 	dispatch('zipcode/clearList');
 };
 
-export default {
+const actions: ActionTree<State, any> = {
 	updateDataSource,
 	clearAutocompleteList
-} as ActionTree<State, any>;
+};
+
+export default actions;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,5 +1,5 @@
-import * as Vue from 'vue';
-import * as Vuex from 'vuex';
+import Vue from 'vue';
+import Vuex from 'vuex';
 
 import actions from './actions';
 import mutations from './mutations';

--- a/src/store/mutations.ts
+++ b/src/store/mutations.ts
@@ -3,8 +3,10 @@ import { MutationTree } from 'vuex';
 import { DATA_SOURCE } from './mutation-types';
 import { State } from './state';
 
-export default {
+const mutations: MutationTree<State> = {
 	[DATA_SOURCE](state: State, newDataSource: AddressEntry[]) {
 		state.dataSource = newDataSource;
 	}
-} as MutationTree<State>;
+};
+
+export default mutations;

--- a/src/vue-shims.d.ts
+++ b/src/vue-shims.d.ts
@@ -1,5 +1,5 @@
 declare module '*.vue' {
-	import * as Vue from 'vue';
+	import Vue from 'vue';
 	export default Vue;
 }
 declare interface Window {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
 			"es2015"
 		],
 		"moduleResolution": "node",
-		"module": "commonjs",
+		"module": "es2015",
 		"target": "es5",
 		"experimentalDecorators": true,
 		"outDir": "./dist/",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1555,6 +1555,13 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+cross-env@^5.0.5:
+  version "5.0.5"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.0.5.tgz#4383d364d9660873dd185b398af3bfef5efffef3"
+  dependencies:
+    cross-spawn "^5.1.0"
+    is-windows "^1.0.0"
+
 cross-spawn@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-3.0.1.tgz#1256037ecb9f0c5f79e3d6ef135e30770184b982"
@@ -3200,6 +3207,10 @@ is-typedarray@~1.0.0:
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
+
+is-windows@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.1.tgz#310db70f742d259a16a369202b51af84233310d9"
 
 is-wsl@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
- Change TypeScript's `module` from `commonjs` to `es2015`.
- Fix `ts-node` problem with `es2015` module. (`ts-node` hasn't supported `es2015` yet. More info TypeStrong/ts-node#212)