### PR TITLE
Use leven instead of string-similarity

### DIFF
--- a/build/webpack.esm.config.ts
+++ b/build/webpack.esm.config.ts
@@ -24,9 +24,8 @@ const config: webpack.Configuration = merge(baseConfig, {
 	],
 	externals: {
 		'array-filter': 'array-filter',
-		'string-similarity': 'string-similarity',
+		'leven': 'leven',
 		'vue': 'vue',
-		'vuex': 'vuex',
 		'@/data/db.json': './db.json'
 	}
 });

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "@types/extract-text-webpack-plugin": "^3.0.0",
     "@types/mocha": "^2.2.41",
     "@types/node": "8",
-    "@types/string-similarity": "^1.2.0",
     "@types/webpack": "^3.0.8",
     "autoprefixer": "^7.1.2",
     "avoriaz": "^6.0.1",
@@ -110,6 +109,6 @@
   },
   "dependencies": {
     "array-filter": "^1.0.0",
-    "string-similarity": "^1.2.0"
+    "leven": "^2.1.0"
   }
 }

--- a/src/lib/utils/calculate-similarity.ts
+++ b/src/lib/utils/calculate-similarity.ts
@@ -1,4 +1,4 @@
-import * as stringSimilarity from 'string-similarity';
+import * as leven from 'leven';
 
 /**
  * Calculate similarity between query and address data.
@@ -10,13 +10,13 @@ import * as stringSimilarity from 'string-similarity';
 function calculateSimilarity(query: string, addressData: AddressEntry): number {
 	let { district, amphoe, province, zipcode } = addressData;
 	let similarities = [
-		stringSimilarity.compareTwoStrings(query, district),
-		stringSimilarity.compareTwoStrings(query, amphoe),
-		stringSimilarity.compareTwoStrings(query, province),
-		stringSimilarity.compareTwoStrings(query, zipcode.toString())
+		leven(query, district),
+		leven(query, amphoe),
+		leven(query, province),
+		leven(query, zipcode.toString())
 	];
 
-	return Math.max(...similarities);
+	return Math.min(...similarities);
 }
 
 export default calculateSimilarity;

--- a/yarn.lock
+++ b/yarn.lock
@@ -87,10 +87,6 @@
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/@types/source-map/-/source-map-0.5.2.tgz#973459e744cc7445c85b97f770275b479b138e08"
 
-"@types/string-similarity@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/@types/string-similarity/-/string-similarity-1.2.0.tgz#0598ffdac808067953e1da480fda85e8fde80560"
-
 "@types/tapable@*":
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-0.2.4.tgz#8181a228da46185439300e600c5ae3b3b3982585"
@@ -3978,6 +3974,10 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
+leven@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"
+
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
@@ -4073,7 +4073,7 @@ lodash@^3.8.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
 
-lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.0, lodash@~4.17.4:
+lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.0, lodash@~4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -6302,12 +6302,6 @@ stream-http@^2.7.2:
 strict-uri-encode@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
-
-string-similarity@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/string-similarity/-/string-similarity-1.2.0.tgz#d75153cb383846318b7a39a8d9292bb4db4e9c30"
-  dependencies:
-    lodash "^4.13.1"
 
 string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Use [`leven`](https://github.com/sindresorhus/leven) instead of [`string-similarity`](https://github.com/aceakash/string-similarity) for finding string similarity.

# Size Comparison

## `string-similarity`:

```
  File                            Size     Gzip
  ----                            ----     ----
  db.js                           197 kB   57.4 kB
  db.min.js                       191 kB   56.4 kB
  vue-thailand-address.js         167 kB   32.5 kB
  vue-thailand-address.common.js  54.7 kB  9.29 kB
  vue-thailand-address.esm.js     54.7 kB  9.28 kB
  vue-thailand-address.min.js     40.3 kB  11 kB
  vue-thailand-address.css        1.94 kB  707 B
  vue-thailand-address.min.css    1.64 kB  651 B
  ----                            ----     ----
  Total:                          708 kB   177 kB
```

## `leven`:

```
  File                            Size     Gzip
  ----                            ----     ----
  db.js                           197 kB   57.4 kB
  db.min.js                       191 kB   56.4 kB
  vue-thailand-address.js         56.3 kB  9.71 kB
  vue-thailand-address.common.js  54.5 kB  9.28 kB
  vue-thailand-address.esm.js     54.5 kB  9.27 kB
  vue-thailand-address.min.js     17.9 kB  4.77 kB
  vue-thailand-address.css        1.94 kB  707 B
  vue-thailand-address.min.css    1.64 kB  651 B
  ----                            ----     ----
  Total:                          574 kB   148 kB
```
> Generated by [`dist-size`](https://github.com/egoist/dist-size).

# Size Summary

Dist file sizes are decreased substantially. 🎉 

| **Files**                      | `string-similarity` | `leven` | `string-similarity` (gzip) | `leven` (gzip) |
|--------------------------------|---------------------|---------|----------------------------|----------------|
| vue-thailand-address.js        | 167 kB              | 56.3 kB | 32.5 kB                    | 9.71 kB        |
| vue-thailand-address.min.js    | 40.3 kB             | 17.9 kB | 11 kB                      | 4.77 kB        |
| vue-thailand-address.common.js | 54.7 kB             | 54.5 kB | 9.29 kB                    | 9.28 kB        |
| vue-thailand-address.esm.js    | 54.7 kB             | 54.5 kB | 9.28 kB                    | 9.27 kB        |